### PR TITLE
Use unbuffered logging and always restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY --from=build-venv /venv /venv
 COPY main.py /app/main.py
 COPY .env /app/.env
 WORKDIR /app
-ENTRYPOINT ["/venv/bin/python3", "main.py"]
+ENTRYPOINT ["/venv/bin/python3", "-u", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,4 @@ services:
     build:
       dockerfile: Dockerfile
       context: .
+    restart: unless-stopped


### PR DESCRIPTION
Change a setting to use unbuffered logs in Python (so logs show properly in docker-compose logs), and added the setting to have the container auto-restart on crashes.